### PR TITLE
Trenger ikke logge "besøk" - dette gjøres av navigatøren

### DIFF
--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -28,11 +28,3 @@ export const logNavigering = (
     applikasjon: 'ef-minside',
   });
 };
-
-export const logBesøk = (side: string) => {
-  logEvent('besøk', {
-    side,
-    team_id: 'familie',
-    applikasjon: 'familie-ef-ettersending',
-  });
-};

--- a/src/pages/Forside/Forside.tsx
+++ b/src/pages/Forside/Forside.tsx
@@ -12,8 +12,6 @@ import Snarveier from './Snarveier';
 import LenkePanelStorListe from './LenkePanelStorListe';
 import StønadPanelListe from './StønadPanelListe';
 import { GuidePanel } from '@navikt/ds-react';
-import { useEffect } from 'react';
-import { logBesøk } from '../../amplitude/amplitude';
 import { useApp } from '../../context/AppContext';
 
 const HovedInnhold = styled(ResponsiveFlexbox)`
@@ -40,10 +38,6 @@ const TittelContainer = styled.div`
 
 const Forside: React.FC = () => {
   const { personData } = useApp();
-
-  useEffect(() => {
-    logBesøk('Forside');
-  }, []);
 
   const panelTekstPrefix = personData.visningsnavn
     ? `Hei, ${personData.visningsnavn}. `


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Besøk registreres av dekoratør. Fjerner derfor logging av besøk fra app. 


Deployet i preprod. Ser ut til å fungerer greit. Får ikke to besøk hver gang nå. 
Den øverste collecten er ikke relatert til besøk ("event_type":"$identify") 

![image](https://github.com/navikt/familie-ef-minside/assets/53942238/06fa075f-57ff-476d-af92-8040d6b07777)

vs main: 
![image](https://github.com/navikt/familie-ef-minside/assets/53942238/9e1e3378-eb73-4f2e-a69c-4673df1b9498)


