### PR TITLE
Vitest

### DIFF
--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -13,11 +13,12 @@ jobs:
           node-version: '18'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
-      - name: Build and test
+      - name: Npm install, test and build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
         run: |
           npm ci
+          npm run test
           npm run build
       - name: Npm build server
         working-directory: ./server

--- a/.github/workflows/build_n_deploy_dev.yaml
+++ b/.github/workflows/build_n_deploy_dev.yaml
@@ -22,11 +22,12 @@ jobs:
           node-version: '18'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
-      - name: Npm install and build
+      - name: Npm install, test and build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
         run: |
           npm ci
+          npm run test
           npm run build
       - name: Npm build server
         working-directory: ./server

--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -24,11 +24,12 @@ jobs:
           node-version: '18'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
-      - name: Npm install and build
+      - name: Npm install, test and build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
         run: |
           npm ci
+          npm run test
           npm run build
       - name: Npm build server
         working-directory: ./server

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ TOKENX_API=<ACCESS_TOKEN>
 3. `npm install`
 4. `npm run start:preprod`
 
+## Testing
+Appen benytter [vitest](https://vitest.dev/) til frontend-testing. Legg gjerne til nye tester etter oppdateringer av utility-filene. 
+For å kjøre opp tester lokalt kan man kjøre `npm run test`. 
+
 ## Henvendelser
 Interne henvendelser kan sendes via Slack i kanalen #team-familie.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3",
         "url-loader": "^4.1.1",
+        "vitest": "^1.3.1",
         "webpack": "^5.90.3",
         "webpack-cli": "^5.1.4"
       }
@@ -2001,6 +2002,374 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
       "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2735,6 +3104,175 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
+      "integrity": "sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.0.tgz",
+      "integrity": "sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.0.tgz",
+      "integrity": "sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.0.tgz",
+      "integrity": "sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.0.tgz",
+      "integrity": "sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.0.tgz",
+      "integrity": "sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.0.tgz",
+      "integrity": "sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.0.tgz",
+      "integrity": "sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
+      "integrity": "sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.0.tgz",
+      "integrity": "sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.0.tgz",
+      "integrity": "sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.0.tgz",
+      "integrity": "sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.0.tgz",
+      "integrity": "sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@sentry-internal/feedback": {
       "version": "7.102.1",
@@ -3776,6 +4314,102 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@vitest/expect": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.3.1.tgz",
+      "integrity": "sha512-xofQFwIzfdmLLlHa6ag0dPV8YsnKOCP1KdAeVVh34vSjN2dcUiXYCD9htu/9eM7t8Xln4v03U9HLxLpPlsXdZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "1.3.1",
+        "@vitest/utils": "1.3.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.3.1.tgz",
+      "integrity": "sha512-5FzF9c3jG/z5bgCnjr8j9LNq/9OxV2uEBAITOXfoe3rdZJTdO7jzThth7FXv/6b+kdY65tpRQB7WaKhNZwX+Kg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "1.3.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.3.1.tgz",
+      "integrity": "sha512-EF++BZbt6RZmOlE3SuTPu/NfwBF6q4ABS37HHXzs2LUVPBLx2QoY/K0fKpRChSo8eLiuxcbCVfqKgx/dplCDuQ==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.3.1.tgz",
+      "integrity": "sha512-xAcW+S099ylC9VLU7eZfdT9myV67Nor9w9zhf0mGCYJSO+zM2839tOeROTdikOi/8Qeusffvxb/MyBSOja1Uig==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.3.1.tgz",
+      "integrity": "sha512-d3Waie/299qqRyHTm2DjADeTaNdNSVsnwHPWrs20JMpjh6eiVq7ggggweO8rc4arhf6rRkWuHKwvxGvejUXZZQ==",
+      "dev": true,
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
@@ -4000,9 +4634,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -4030,9 +4664,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
-      "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -4218,6 +4852,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/asynckit": {
@@ -4540,6 +5183,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
@@ -4615,6 +5267,24 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -4627,6 +5297,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -5474,6 +6156,18 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5576,6 +6270,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -5820,6 +6523,44 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
       "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
       "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -6206,6 +6947,15 @@
       "dev": true,
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/esutils": {
@@ -6877,6 +7627,15 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -8095,6 +8854,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -8179,6 +8944,22 @@
         "node": ">=8.9.0"
       }
     },
+    "node_modules/local-pkg": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+      "integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
+      "dev": true,
+      "dependencies": {
+        "mlly": "^1.4.2",
+        "pkg-types": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8223,6 +9004,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -8239,6 +9029,18 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-error": {
@@ -8465,6 +9267,18 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.6.1.tgz",
+      "integrity": "sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.3",
+        "pathe": "^1.1.2",
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.3.2"
       }
     },
     "node_modules/mri": {
@@ -11668,6 +12482,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -11780,6 +12609,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.2.0",
+        "mlly": "^1.2.0",
+        "pathe": "^1.1.0"
       }
     },
     "node_modules/postcss": {
@@ -11985,6 +12825,32 @@
       "dependencies": {
         "lodash": "^4.17.20",
         "renderkid": "^3.0.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/pretty-quick": {
@@ -12341,6 +13207,12 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/react-property": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
@@ -12604,6 +13476,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.0.tgz",
+      "integrity": "sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.12.0",
+        "@rollup/rollup-android-arm64": "4.12.0",
+        "@rollup/rollup-darwin-arm64": "4.12.0",
+        "@rollup/rollup-darwin-x64": "4.12.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.12.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.12.0",
+        "@rollup/rollup-linux-arm64-musl": "4.12.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.12.0",
+        "@rollup/rollup-linux-x64-gnu": "4.12.0",
+        "@rollup/rollup-linux-x64-musl": "4.12.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.12.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.12.0",
+        "@rollup/rollup-win32-x64-msvc": "4.12.0",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rrweb-cssom": {
@@ -12994,6 +13898,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -13111,6 +14021,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -13127,6 +14043,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
+      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -13171,6 +14093,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.0.0.tgz",
+      "integrity": "sha512-f9vHgsCWBq2ugHAkGMiiYY+AYG0D/cbloKKg0nhaaaSNsujdGIpVXCNsrJpCKr5M0f4aI31mr13UjY6GAuXCKA==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-8.0.3.tgz",
+      "integrity": "sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw==",
+      "dev": true
     },
     "node_modules/style-loader": {
       "version": "3.3.4",
@@ -13565,6 +14505,30 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/tinybench": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.6.0.tgz",
+      "integrity": "sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==",
+      "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.2.tgz",
+      "integrity": "sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -13705,6 +14669,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
@@ -13746,6 +14719,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.4.0.tgz",
+      "integrity": "sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==",
+      "dev": true
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
@@ -13927,6 +14906,310 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.5.tgz",
+      "integrity": "sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.19.3",
+        "postcss": "^8.4.35",
+        "rollup": "^4.2.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.3.1.tgz",
+      "integrity": "sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.4.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.3.1.tgz",
+      "integrity": "sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "1.3.1",
+        "@vitest/runner": "1.3.1",
+        "@vitest/snapshot": "1.3.1",
+        "@vitest/spy": "1.3.1",
+        "@vitest/utils": "1.3.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.2",
+        "vite": "^5.0.0",
+        "vite-node": "1.3.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.3.1",
+        "@vitest/ui": "1.3.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/vitest/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/vitest/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/vitest/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -14437,6 +15720,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wildcard": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start:dev": "npm run build:dev-server && NODE_ENV=development ENV=localhost PUBLIC_URL=/familie/alene-med-barn/minside node --es-module-specifier-resolution=node --trace-deprecation server/build/server-lokal.js",
     "start:preprod": "npm run build:dev-server && NODE_ENV=development BRUK_DEV_API=true ENV=localhost PUBLIC_URL=/familie/alene-med-barn/minside node --es-module-specifier-resolution=node --trace-deprecation server/build/server-lokal.js",
     "build:dev-server": "cd server && tsc --build --verbose && cd ..",
-    "test": "vitest --exclude '**/build/**'",
+    "test": "vitest run --exclude '**/build/**'",
     "postinstall": "cd server && npm ci && cd .."
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start:dev": "npm run build:dev-server && NODE_ENV=development ENV=localhost PUBLIC_URL=/familie/alene-med-barn/minside node --es-module-specifier-resolution=node --trace-deprecation server/build/server-lokal.js",
     "start:preprod": "npm run build:dev-server && NODE_ENV=development BRUK_DEV_API=true ENV=localhost PUBLIC_URL=/familie/alene-med-barn/minside node --es-module-specifier-resolution=node --trace-deprecation server/build/server-lokal.js",
     "build:dev-server": "cd server && tsc --build --verbose && cd ..",
+    "test": "vitest --exclude '**/build/**'",
     "postinstall": "cd server && npm ci && cd .."
   },
   "husky": {
@@ -83,6 +84,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3",
     "url-loader": "^4.1.1",
+    "vitest": "^1.3.1",
     "webpack": "^5.90.3",
     "webpack-cli": "^5.1.4"
   }

--- a/src/pages/Dokumentoversikt/utils.test.ts
+++ b/src/pages/Dokumentoversikt/utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import {
+  DokumentInfo,
+  Journalpost,
+  JournalpostType,
+  Variantformat,
+} from '../../interfaces/journalpost';
+import { utledDetailTekst } from './utils';
+
+describe('sjekk - utled detailtekst for dokumentoversikt', () => {
+  test('utled tekst gitt journalpost', () => {
+    const journalpostInnkommende = lagJournalpost(JournalpostType.I, '2024-02-20T15:38:08');
+    const journalpostUtgående = lagJournalpost(JournalpostType.U, '2024-02-19T09:54:03');
+    const journalpostNotat = lagJournalpost(JournalpostType.N, '2024-01-24T10:52:57');
+
+    const detailTekstInnkommende = utledDetailTekst(journalpostInnkommende);
+    const detailTekstUtgående = utledDetailTekst(journalpostUtgående);
+    const detailTekstNotat = utledDetailTekst(journalpostNotat);
+
+    expect(detailTekstInnkommende).toBe('Sendt av deg: 20.02.2024 kl.15:38');
+    expect(detailTekstUtgående).toBe('Sendt fra NAV: 19.02.2024 kl.09:54');
+    expect(detailTekstNotat).toBe('24.01.2024 kl.10:52');
+  });
+});
+
+const lagDokumentInfo = (): DokumentInfo => {
+  return {
+    dokumentId: '',
+    tittel: '',
+    variantformat: Variantformat.ARKIV,
+    filtype: '',
+  };
+};
+
+const lagJournalpost = (journalpostType: JournalpostType, dato: string): Journalpost => {
+  return {
+    journalpostId: '',
+    journalpostType: journalpostType,
+    dato: dato,
+    hovedDokument: lagDokumentInfo(),
+    vedlegg: [],
+  };
+};

--- a/src/pages/Forside/utils.test.ts
+++ b/src/pages/Forside/utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'vitest';
+import { utledKomponentTittel } from './utils';
+
+describe('sjekk - utled komponenttittel', () => {
+  test('utled riktig tittel gitt stønadType', () => {
+    const tittelOvergangsstønad = utledKomponentTittel('overgangsstønad');
+    const tittelBarnetilsyn = utledKomponentTittel('barnetilsyn');
+    const tittelSkolepenger = utledKomponentTittel('skolepenger');
+
+    expect(tittelOvergangsstønad).toBe('Overgangsstønad');
+    expect(tittelBarnetilsyn).toBe('Stønad til barnetilsyn');
+    expect(tittelSkolepenger).toBe('Stønad til skolepenger');
+  });
+});

--- a/src/pages/Stønadoversikt/StønadTabell.tsx
+++ b/src/pages/Stønadoversikt/StønadTabell.tsx
@@ -3,7 +3,7 @@ import { Stønad, Stønadsperiode, StønadType } from '../../interfaces/stønade
 import { Alert, BodyLong, HStack, Table } from '@navikt/ds-react';
 import {
   formaterIsoDato,
-  formaterIsoÅrMåned,
+  formaterIsoMånedÅr,
   formaterTallMedTusenSkille,
 } from '../../utils/formatter';
 import styled from 'styled-components';
@@ -77,9 +77,9 @@ const TabellRad: React.FC<{
 }> = ({ periode, stønadType, kolonneBredde }) => {
   const fraDato = formaterIsoDato(periode.fraDato);
   const tilDato = formaterIsoDato(periode.tilDato);
-  const årMåned = formaterIsoÅrMåned(periode.fraDato);
+  const månedÅr = formaterIsoMånedÅr(periode.fraDato);
 
-  const beløpsperiode = stønadType === 'skolepenger' ? `${årMåned}` : `${fraDato} - ${tilDato}`;
+  const beløpsperiode = stønadType === 'skolepenger' ? `${månedÅr}` : `${fraDato} - ${tilDato}`;
 
   const beløp = `${formaterTallMedTusenSkille(periode.beløp)} kr`;
 

--- a/src/pages/Stønadoversikt/utils.test.ts
+++ b/src/pages/Stønadoversikt/utils.test.ts
@@ -246,6 +246,12 @@ describe('sjekk - skal sortere stønadsperiodene på dato og slå sammen sammenh
     expect(perioder[2]).toEqual(lagPeriode('2023-05-01', '2023-10-31', 22000));
     expect(perioder[3]).toEqual(lagPeriode('2023-01-01', '2023-03-30', 20900));
   });
+
+  test('skal feile', () => {
+    const perioder = utledPerioder('barnetilsyn', usammenhengendePerioderLiktBeløp());
+
+    expect(perioder).toHaveLength(5);
+  });
 });
 
 const sammenHengendePerioderMedLiktBeløp = () => [

--- a/src/pages/Stønadoversikt/utils.test.ts
+++ b/src/pages/Stønadoversikt/utils.test.ts
@@ -246,12 +246,6 @@ describe('sjekk - skal sortere stønadsperiodene på dato og slå sammen sammenh
     expect(perioder[2]).toEqual(lagPeriode('2023-05-01', '2023-10-31', 22000));
     expect(perioder[3]).toEqual(lagPeriode('2023-01-01', '2023-03-30', 20900));
   });
-
-  test('skal feile', () => {
-    const perioder = utledPerioder('barnetilsyn', usammenhengendePerioderLiktBeløp());
-
-    expect(perioder).toHaveLength(5);
-  });
 });
 
 const sammenHengendePerioderMedLiktBeløp = () => [

--- a/src/pages/Stønadoversikt/utils.test.ts
+++ b/src/pages/Stønadoversikt/utils.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, test } from 'vitest';
+import {
+  utledBeskrivelse,
+  utledBreadCrumb,
+  utledBrødtekst,
+  utledHeaderTekst,
+  utledKolonnebredde,
+  utledPerioder,
+  utledStønadTekst,
+  utledVedtak,
+} from './utils';
+import { JournalpostType, Variantformat } from '../../interfaces/journalpost';
+
+describe('sjekk - formateringer av tekst og perioder stønadsidene', () => {
+  test('skal utlede breadcrumb gitt stønadType', () => {
+    const overgangsstønad = utledBreadCrumb('overgangsstønad');
+    const barnetilsyn = utledBreadCrumb('barnetilsyn');
+    const skolepenger = utledBreadCrumb('skolepenger');
+
+    expect(overgangsstønad).toEqual(
+      lagBreadCrumb('/familie/alene-med-barn/minside/overgangsstonad', 'Din overgangsstønad')
+    );
+    expect(barnetilsyn).toEqual(
+      lagBreadCrumb('/familie/alene-med-barn/minside/barnetilsyn', 'Din stønad til barnetilsyn')
+    );
+    expect(skolepenger).toEqual(
+      lagBreadCrumb('/familie/alene-med-barn/minside/skolepenger', 'Din stønad til skolepenger')
+    );
+  });
+
+  test('skal utlede stønadstekst gitt stønadType', () => {
+    const overgangsstønad = utledStønadTekst('overgangsstønad');
+    const barnetilsyn = utledStønadTekst('barnetilsyn');
+    const skolepenger = utledStønadTekst('skolepenger');
+
+    expect(overgangsstønad).toBe('Din overgangsstønad');
+    expect(barnetilsyn).toBe('Din stønad til barnetilsyn');
+    expect(skolepenger).toBe('Din stønad til skolepenger');
+  });
+
+  test('skal utlede beskrivelse gitt stønadType', () => {
+    const overgangsstønad = utledBeskrivelse('overgangsstønad');
+    const barnetilsyn = utledBeskrivelse('barnetilsyn');
+    const skolepenger = utledBeskrivelse('skolepenger');
+
+    expect(overgangsstønad).toBe('Her vises dine vedtakdsdokumenter for overgangsstønad.');
+    expect(barnetilsyn).toBe('Her vises dine vedtakdsdokumenter for stønad til barnetilsyn.');
+    expect(skolepenger).toBe('Her vises dine vedtakdsdokumenter for stønad til skolepenger.');
+  });
+
+  test('skal utlede brødtekst gitt stønadType', () => {
+    const overgangsstønad = utledBrødtekst('overgangsstønad');
+    const barnetilsyn = utledBrødtekst('barnetilsyn');
+    const skolepenger = utledBrødtekst('skolepenger');
+
+    expect(overgangsstønad).toBe(
+      'Tabellen viser periodene dine med overgangsstønad og hvor mye du har fått eller får i stønad\n        per måned før skatt. For å se hvordan vi har regnet ut stønadsbeløpet, må du lese vedtaket\n        ditt. Du finner alle vedtakene dine i dokumentoversikten lengre ned på siden.'
+    );
+    expect(barnetilsyn).toBe(
+      'Tabellen viser periodene dine med barnetilsyn og hvor mye du har fått eller får i stønad\n        per måned. For å se hvordan vi har regnet ut stønadsbeløpet, må du lese vedtaket\n        ditt. Du finner alle vedtakene dine i dokumentoversikten lengre ned på siden.'
+    );
+    expect(skolepenger).toBe(
+      'Tabellen viser utbetalingsmåndene dine med skolepenger. For å se hvordan vi har regnet ut stønadsbeløpet, må du lese vedtaket\n        ditt. Du finner alle vedtakene dine i dokumentoversikten lengre ned på siden.'
+    );
+  });
+
+  test('skal utelde headertekst gitt stønadType', () => {
+    const overgangsstønad = utledHeaderTekst('overgangsstønad');
+    const barnetilsyn = utledHeaderTekst('barnetilsyn');
+    const skolepenger = utledHeaderTekst('skolepenger');
+
+    expect(overgangsstønad).toEqual({
+      headerCelle1: 'Periode',
+      headerCelle2: 'Beløp per måned før skatt',
+    });
+    expect(barnetilsyn).toEqual({ headerCelle1: 'Periode', headerCelle2: 'Beløp per måned' });
+    expect(skolepenger).toEqual({ headerCelle1: 'Utbetalingsmåned', headerCelle2: 'Beløp' });
+  });
+
+  test('skal utlede kolonnebredde gitt beløp', () => {
+    expect(utledKolonnebredde(5)).toBe('1.75rem');
+    expect(utledKolonnebredde(10)).toBe('2.3rem');
+    expect(utledKolonnebredde(100)).toBe('2.85rem');
+    expect(utledKolonnebredde(1000)).toBe('3.65rem');
+    expect(utledKolonnebredde(10000)).toBe('4.2rem');
+    expect(utledKolonnebredde(100000)).toBe('4.8rem');
+  });
+});
+
+describe('skal utlede alle journalposter som er et vedtak gitt stønadstype', () => {
+  test('overgangsstønad', () => {
+    const journalposter = utledVedtak(dummyJournalposter, 'overgangsstønad');
+
+    expect(journalposter).toHaveLength(3);
+    expect(journalposter[0].hovedDokument.tittel).toBe('Vedtak om revurdert overgangsstønad');
+    expect(journalposter[1].hovedDokument.tittel).toBe('Vedtak om revurdert overgangsstønad');
+    expect(journalposter[2].hovedDokument.tittel).toBe('Vedtak om innvilget overgangsstønad');
+  });
+
+  test('barnetilsyn', () => {
+    const journalposter = utledVedtak(dummyJournalposter, 'barnetilsyn');
+
+    expect(journalposter).toHaveLength(3);
+    expect(journalposter[0].hovedDokument.tittel).toBe(
+      'Vedtak om revurdert stønad til barnetilsyn'
+    );
+    expect(journalposter[1].hovedDokument.tittel).toBe(
+      'Vedtak om revurdert stønad til barnetilsyn'
+    );
+    expect(journalposter[2].hovedDokument.tittel).toBe('Vedtak om avslått stønad til barnetilsyn');
+  });
+
+  test('skolepenger', () => {
+    const journalposter = utledVedtak(dummyJournalposter, 'skolepenger');
+
+    expect(journalposter).toHaveLength(2);
+    expect(journalposter[0].hovedDokument.tittel).toBe(
+      'Vedtak om revurdert stønad til skolepenger'
+    );
+    expect(journalposter[1].hovedDokument.tittel).toBe(
+      'Vedtak om innvilget stønad til skolepenger'
+    );
+  });
+});
+
+describe('sjekk - skal sortere stønadsperiodene på dato for skolepenger', () => {
+  test('skal sortere fra nyeste til eldste periode gitt sammenhengende perioder med likt beløp', () => {
+    const perioder = utledPerioder('skolepenger', sammenHengendePerioderMedLiktBeløp());
+
+    expect(perioder).toHaveLength(4);
+    expect(perioder[0]).toEqual(lagPeriode('2024-05-01', '2024-08-31', 2000));
+    expect(perioder[1]).toEqual(lagPeriode('2024-01-01', '2024-04-30', 22000));
+    expect(perioder[2]).toEqual(lagPeriode('2023-05-01', '2023-12-31', 22000));
+    expect(perioder[3]).toEqual(lagPeriode('2023-01-01', '2023-04-30', 20900));
+  });
+
+  test('skal sortere fra nyeste til eldste periode gitt sammenhengende perioder med likt beløp som ikke er sortert', () => {
+    const perioder = utledPerioder('skolepenger', sammenHengendePerioderMedLiktBeløpIkkeSortert());
+
+    expect(perioder).toHaveLength(4);
+    expect(perioder[0]).toEqual(lagPeriode('2024-05-01', '2024-08-31', 2000));
+    expect(perioder[1]).toEqual(lagPeriode('2024-01-01', '2024-04-30', 22000));
+    expect(perioder[2]).toEqual(lagPeriode('2023-05-01', '2023-12-31', 22000));
+    expect(perioder[3]).toEqual(lagPeriode('2023-01-01', '2023-04-30', 20900));
+  });
+
+  test('skal sortere fra nyeste til eldste periode gitt sammenhengende perioder med ulike beløp', () => {
+    const perioder = utledPerioder('skolepenger', sammenHengendePerioderMedUlikeBeløp());
+
+    expect(perioder).toHaveLength(4);
+    expect(perioder[0]).toEqual(lagPeriode('2024-05-01', '2024-08-31', 2000));
+    expect(perioder[1]).toEqual(lagPeriode('2024-01-01', '2024-04-30', 22001));
+    expect(perioder[2]).toEqual(lagPeriode('2023-05-01', '2023-12-31', 22000));
+    expect(perioder[3]).toEqual(lagPeriode('2023-01-01', '2023-04-30', 20900));
+  });
+
+  test('skal sortere fra nyeste til eldste periode gitt usammenhengende perioder med like beløp', () => {
+    const perioder = utledPerioder('skolepenger', usammenhengendePerioderLiktBeløp());
+
+    expect(perioder).toHaveLength(4);
+    expect(perioder[0]).toEqual(lagPeriode('2024-05-01', '2024-08-31', 2000));
+    expect(perioder[1]).toEqual(lagPeriode('2024-01-01', '2024-02-30', 22000));
+    expect(perioder[2]).toEqual(lagPeriode('2023-05-01', '2023-10-31', 22000));
+    expect(perioder[3]).toEqual(lagPeriode('2023-01-01', '2023-03-30', 20900));
+  });
+});
+
+describe('sjekk - skal sortere stønadsperiodene på dato og slå sammen sammenhengende perioder med like beløp for overgangsstønad ', () => {
+  test('skal sortere og slå sammen perioder gitt sammenhengende perioder med like beløp', () => {
+    const perioder = utledPerioder('overgangsstønad', sammenHengendePerioderMedLiktBeløp());
+
+    expect(perioder).toHaveLength(3);
+    expect(perioder[0]).toEqual(lagPeriode('2024-05-01', '2024-08-31', 2000));
+    expect(perioder[1]).toEqual(lagPeriode('2023-05-01', '2024-04-30', 22000));
+    expect(perioder[2]).toEqual(lagPeriode('2023-01-01', '2023-04-30', 20900));
+  });
+
+  test('skal sortere og slå sammen gitt sammenhengende perioder med like beløp som ikke er sortert', () => {
+    const perioder = utledPerioder(
+      'overgangsstønad',
+      sammenHengendePerioderMedLiktBeløpIkkeSortert()
+    );
+
+    expect(perioder).toHaveLength(3);
+    expect(perioder[0]).toEqual(lagPeriode('2024-05-01', '2024-08-31', 2000));
+    expect(perioder[1]).toEqual(lagPeriode('2023-05-01', '2024-04-30', 22000));
+    expect(perioder[2]).toEqual(lagPeriode('2023-01-01', '2023-04-30', 20900));
+  });
+
+  test('skal sortere og ikke slå sammen gitt sammenhengende perioder med ulike beløp', () => {
+    const perioder = utledPerioder('overgangsstønad', sammenHengendePerioderMedUlikeBeløp());
+
+    expect(perioder).toHaveLength(4);
+    expect(perioder[0]).toEqual(lagPeriode('2024-05-01', '2024-08-31', 2000));
+    expect(perioder[1]).toEqual(lagPeriode('2024-01-01', '2024-04-30', 22001));
+    expect(perioder[2]).toEqual(lagPeriode('2023-05-01', '2023-12-31', 22000));
+    expect(perioder[3]).toEqual(lagPeriode('2023-01-01', '2023-04-30', 20900));
+  });
+
+  test('skal sortere og ikke slå sammen gitt usammenhengende perioder med like beløp', () => {
+    const perioder = utledPerioder('overgangsstønad', usammenhengendePerioderLiktBeløp());
+
+    expect(perioder).toHaveLength(4);
+    expect(perioder[0]).toEqual(lagPeriode('2024-05-01', '2024-08-31', 2000));
+    expect(perioder[1]).toEqual(lagPeriode('2024-01-01', '2024-02-30', 22000));
+    expect(perioder[2]).toEqual(lagPeriode('2023-05-01', '2023-10-31', 22000));
+    expect(perioder[3]).toEqual(lagPeriode('2023-01-01', '2023-03-30', 20900));
+  });
+});
+
+describe('sjekk - skal sortere stønadsperiodene på dato og slå sammen sammenhengende perioder med like beløp for barnetilsyn ', () => {
+  test('skal sortere og slå sammen perioder gitt sammenhengende perioder med like beløp', () => {
+    const perioder = utledPerioder('barnetilsyn', sammenHengendePerioderMedLiktBeløp());
+
+    expect(perioder).toHaveLength(3);
+    expect(perioder[0]).toEqual(lagPeriode('2024-05-01', '2024-08-31', 2000));
+    expect(perioder[1]).toEqual(lagPeriode('2023-05-01', '2024-04-30', 22000));
+    expect(perioder[2]).toEqual(lagPeriode('2023-01-01', '2023-04-30', 20900));
+  });
+
+  test('skal sortere og slå sammen gitt sammenhengende perioder med like beløp som ikke er sortert', () => {
+    const perioder = utledPerioder('barnetilsyn', sammenHengendePerioderMedLiktBeløpIkkeSortert());
+
+    expect(perioder).toHaveLength(3);
+    expect(perioder[0]).toEqual(lagPeriode('2024-05-01', '2024-08-31', 2000));
+    expect(perioder[1]).toEqual(lagPeriode('2023-05-01', '2024-04-30', 22000));
+    expect(perioder[2]).toEqual(lagPeriode('2023-01-01', '2023-04-30', 20900));
+  });
+
+  test('skal sortere og ikke slå sammen gitt sammenhengende perioder med ulike beløp', () => {
+    const perioder = utledPerioder('barnetilsyn', sammenHengendePerioderMedUlikeBeløp());
+
+    expect(perioder).toHaveLength(4);
+    expect(perioder[0]).toEqual(lagPeriode('2024-05-01', '2024-08-31', 2000));
+    expect(perioder[1]).toEqual(lagPeriode('2024-01-01', '2024-04-30', 22001));
+    expect(perioder[2]).toEqual(lagPeriode('2023-05-01', '2023-12-31', 22000));
+    expect(perioder[3]).toEqual(lagPeriode('2023-01-01', '2023-04-30', 20900));
+  });
+
+  test('skal sortere og ikke slå sammen gitt usammenhengende perioder med like beløp', () => {
+    const perioder = utledPerioder('barnetilsyn', usammenhengendePerioderLiktBeløp());
+
+    expect(perioder).toHaveLength(4);
+    expect(perioder[0]).toEqual(lagPeriode('2024-05-01', '2024-08-31', 2000));
+    expect(perioder[1]).toEqual(lagPeriode('2024-01-01', '2024-02-30', 22000));
+    expect(perioder[2]).toEqual(lagPeriode('2023-05-01', '2023-10-31', 22000));
+    expect(perioder[3]).toEqual(lagPeriode('2023-01-01', '2023-03-30', 20900));
+  });
+});
+
+const sammenHengendePerioderMedLiktBeløp = () => [
+  lagPeriode('2023-01-01', '2023-04-30', 20900),
+  lagPeriode('2023-05-01', '2023-12-31', 22000),
+  lagPeriode('2024-01-01', '2024-04-30', 22000),
+  lagPeriode('2024-05-01', '2024-08-31', 2000),
+];
+
+const sammenHengendePerioderMedLiktBeløpIkkeSortert = () => [
+  lagPeriode('2023-05-01', '2023-12-31', 22000),
+  lagPeriode('2023-01-01', '2023-04-30', 20900),
+  lagPeriode('2024-05-01', '2024-08-31', 2000),
+  lagPeriode('2024-01-01', '2024-04-30', 22000),
+];
+
+const sammenHengendePerioderMedUlikeBeløp = () => [
+  lagPeriode('2023-01-01', '2023-04-30', 20900),
+  lagPeriode('2023-05-01', '2023-12-31', 22000),
+  lagPeriode('2024-01-01', '2024-04-30', 22001),
+  lagPeriode('2024-05-01', '2024-08-31', 2000),
+];
+
+const usammenhengendePerioderLiktBeløp = () => [
+  lagPeriode('2023-01-01', '2023-03-30', 20900),
+  lagPeriode('2023-05-01', '2023-10-31', 22000),
+  lagPeriode('2024-01-01', '2024-02-30', 22000),
+  lagPeriode('2024-05-01', '2024-08-31', 2000),
+];
+
+const lagDokumentInfo = (tittel: string) => {
+  return {
+    dokumentId: '',
+    tittel: tittel,
+    variantformat: Variantformat.ARKIV,
+    filtype: '',
+  };
+};
+
+const lagJournalpost = (tittel: string) => {
+  return {
+    journalpostId: '',
+    journalpostType: JournalpostType.U,
+    dato: '',
+    hovedDokument: lagDokumentInfo(tittel),
+    vedlegg: [],
+  };
+};
+
+const dummyJournalposter = [
+  lagJournalpost('Ettersending overgangsstønad - enslig mor eller far'),
+  lagJournalpost('Ettersending overgangsstønad - enslig mor eller far'),
+  lagJournalpost('Vedtak om revurdert overgangsstønad'),
+  lagJournalpost('Vedtak om revurdert overgangsstønad'),
+  lagJournalpost('Vedtak om revurdert stønad til skolepenger'),
+  lagJournalpost('Vedtak om innvilget stønad til skolepenger'),
+  lagJournalpost('Vedtak om revurdert stønad til barnetilsyn'),
+  lagJournalpost('Vedtak om revurdert stønad til barnetilsyn'),
+  lagJournalpost('Vedtak om avslått stønad til barnetilsyn'),
+  lagJournalpost('Ettersending barnetilsyn - enslig mor eller far i arbeid'),
+  lagJournalpost('Vedtak om innvilget overgangsstønad'),
+];
+
+const lagPeriode = (fra: string, til: string, beløp: number) => {
+  return {
+    fraDato: fra,
+    tilDato: til,
+    beløp: beløp,
+  };
+};
+
+const lagBreadCrumb = (url: string, title: string) => {
+  return { url: url, title: title, handleInApp: false };
+};

--- a/src/pages/Stønadoversikt/utils.ts
+++ b/src/pages/Stønadoversikt/utils.ts
@@ -45,7 +45,7 @@ export const utledPerioder = (stønadType: StønadType, perioder: Stønadsperiod
     ? sorterStønadsperioder(perioder, 'desc')
     : mergeSammenhengendePerioderMedLikeBeløp(perioder);
 
-export const sorterStønadsperioder = (perioder: Stønadsperiode[], rekkefølge: 'asc' | 'desc') =>
+const sorterStønadsperioder = (perioder: Stønadsperiode[], rekkefølge: 'asc' | 'desc') =>
   perioder
     .slice()
     .sort((a, b) => (rekkefølge === 'asc' ? sorterDatoAsc(a, b) : sorterDatoDesc(a, b)));
@@ -53,7 +53,7 @@ export const sorterStønadsperioder = (perioder: Stønadsperiode[], rekkefølge:
 const sorterDatoAsc = (a: Stønadsperiode, b: Stønadsperiode) => (a.fraDato < b.fraDato ? -1 : 1);
 const sorterDatoDesc = (a: Stønadsperiode, b: Stønadsperiode) => (a.fraDato < b.fraDato ? 1 : -1);
 
-export const mergeSammenhengendePerioderMedLikeBeløp = (perioder: Stønadsperiode[]) => {
+const mergeSammenhengendePerioderMedLikeBeløp = (perioder: Stønadsperiode[]) => {
   const sortertePerioderAsc = sorterStønadsperioder(perioder, 'asc');
 
   const sammenslåttePerioder = sortertePerioderAsc.reduce((acc, periode) => {

--- a/src/utils/constants.test.ts
+++ b/src/utils/constants.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import {
+  breadCrumbBarnetilsyn,
+  breadCrumbDokumentOversikt,
+  breadCrumbOvergangsstønad,
+  breadCrumbSkolepenger,
+  contentWidthDesktop,
+  contentWidthMobile,
+  desktop,
+  mobile,
+} from './constants';
+
+describe('sjekk - globale konstanter', () => {
+  test('skjermbredder', () => {
+    expect(desktop).toBe(948);
+    expect(mobile).toBe(480);
+  });
+
+  test('innholdsbredde', () => {
+    expect(contentWidthDesktop).toBe(932);
+    expect(contentWidthMobile).toBe(458);
+  });
+
+  test('brødsmuler', () => {
+    expect(breadCrumbDokumentOversikt.url).toBe('/familie/alene-med-barn/minside/dokumentoversikt');
+    expect(breadCrumbDokumentOversikt.title).toBe('Dokumentoversikt');
+
+    expect(breadCrumbOvergangsstønad.url).toBe('/familie/alene-med-barn/minside/overgangsstonad');
+    expect(breadCrumbOvergangsstønad.title).toBe('Din overgangsstønad');
+
+    expect(breadCrumbBarnetilsyn.url).toBe('/familie/alene-med-barn/minside/barnetilsyn');
+    expect(breadCrumbBarnetilsyn.title).toBe('Din stønad til barnetilsyn');
+
+    expect(breadCrumbSkolepenger.url).toBe('/familie/alene-med-barn/minside/skolepenger');
+    expect(breadCrumbSkolepenger.title).toBe('Din stønad til skolepenger');
+  });
+});

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { antallDagerMellomDatoer, erPåfølgendeDatoer } from './date';
+
+describe('kalkulering - antall dager mellom datoer', () => {
+  test('skal håndtere etterfølgende datoer', () => {
+    const antallDagerEtterfølgende = antallDagerMellomDatoer('2024-01-23', '2024-01-24');
+    const antallDagerForskjelligMåned = antallDagerMellomDatoer('2024-01-24', '2024-07-12');
+    const antallDagerForskjelligTiår = antallDagerMellomDatoer('1996-01-24', '2024-03-07');
+
+    expect(antallDagerEtterfølgende).toBe(1);
+    expect(antallDagerForskjelligMåned).toBe(170);
+    expect(antallDagerForskjelligTiår).toBe(10270);
+  });
+
+  test('skal håndtere datoer i feil rekkefølge', () => {
+    const antallDagerEtterfølgende = antallDagerMellomDatoer('2024-01-24', '2024-01-23');
+    const antallDagerForskjelligMåned = antallDagerMellomDatoer('2024-07-12', '2024-01-24');
+    const antallDagerForskjelligTiår = antallDagerMellomDatoer('2024-03-07', '1996-01-24');
+
+    expect(antallDagerEtterfølgende).toBe(-1);
+    expect(antallDagerForskjelligMåned).toBe(-170);
+    expect(antallDagerForskjelligTiår).toBe(-10270);
+  });
+});
+
+describe('sjekk - er to datoer påfølgende', () => {
+  test('skal returnere true', () => {
+    const påfølgendeDatoer = erPåfølgendeDatoer('2024-01-23', '2024-01-24');
+    const skuddårsdatoer1 = erPåfølgendeDatoer('2024-02-28', '2024-02-29');
+    const skuddårsdatoer2 = erPåfølgendeDatoer('2024-02-29', '2024-03-01');
+
+    expect(påfølgendeDatoer).toBe(true);
+    expect(skuddårsdatoer1).toBe(true);
+    expect(skuddårsdatoer2).toBe(true);
+  });
+
+  test('skal returnere false', () => {
+    const påfølgendeDatoerFeilRekkefølge = erPåfølgendeDatoer('2024-01-24', '2024-01-23');
+    const skuddårsdatoerIkkeSkuddår1 = erPåfølgendeDatoer('2023-02-28', '2023-02-29');
+    const skuddårsdatoerIkkeSkuddår2 = erPåfølgendeDatoer('2023-02-29', '2023-03-01');
+
+    expect(påfølgendeDatoerFeilRekkefølge).toBe(false);
+    expect(skuddårsdatoerIkkeSkuddår1).toBe(false);
+    expect(skuddårsdatoerIkkeSkuddår2).toBe(false);
+  });
+});

--- a/src/utils/fil.test.ts
+++ b/src/utils/fil.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest';
+import { utledFilUrl } from './fil';
+import { Variantformat } from '../interfaces/journalpost';
+
+describe('dokumentUthenting', () => {
+  test('skal utlede riktig url for uthenting av dokument, gitt journalpostId, dokumentId og variantformat', () => {
+    const url = utledFilUrl('1234', '5678', Variantformat.ARKIV);
+
+    expect(url).toBe(
+      '/familie/alene-med-barn/minside/dokument/journalpost/1234/dokument-pdf/5678/variantformat/ARKIV'
+    );
+  });
+});

--- a/src/utils/fil.test.ts
+++ b/src/utils/fil.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from 'vitest';
 import { utledFilUrl } from './fil';
 import { Variantformat } from '../interfaces/journalpost';
 
-describe('dokumentUthenting', () => {
-  test('skal utlede riktig url for uthenting av dokument, gitt journalpostId, dokumentId og variantformat', () => {
+describe('sjekk - dokumentuthenting', () => {
+  test('skal utlede url for dokument, gitt journalpostId, dokumentId og variantformat', () => {
     const url = utledFilUrl('1234', '5678', Variantformat.ARKIV);
 
     expect(url).toBe(

--- a/src/utils/formatter.test.ts
+++ b/src/utils/formatter.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest';
+import {
+  formaterIsoDato,
+  formaterIsoDatoTid,
+  formaterIsoMånedÅr,
+  formaterNullableIsoDato,
+  formaterTallMedTusenSkille,
+  harTallverdi,
+} from './formatter';
+
+describe('sjekk - formatering av tall, dato og tid', () => {
+  test('nullable-iso-dato skal formateres riktig', () => {
+    const datoStandard = formaterNullableIsoDato('2024-08-31');
+    const datoTid = formaterNullableIsoDato('2024-08-31T12:30:14');
+    const datoUndefined = formaterNullableIsoDato(undefined);
+
+    expect(datoStandard).toBe('31.08.2024');
+    expect(datoTid).toBe('31.08.2024');
+    expect(datoUndefined).toBeUndefined;
+  });
+
+  test('iso-dato skal formateres riktig', () => {
+    const dato = formaterIsoDato('2024-08-31');
+    const datoTid = formaterIsoDato('2024-08-31T12:30:14');
+
+    expect(dato).toBe('31.08.2024');
+    expect(datoTid).toBe('31.08.2024');
+  });
+
+  test('iso-måned-år skal formateres riktig', () => {
+    const månedÅr = formaterIsoMånedÅr('2024-08-31');
+    const månedÅrTid = formaterIsoMånedÅr('2024-08-31T12:30:14');
+
+    expect(månedÅr).toBe('08.2024');
+    expect(månedÅrTid).toBe('08.2024');
+  });
+
+  test('iso-dato-tid skal formateres riktig', () => {
+    const datoTid = formaterIsoDatoTid('2024-08-31T12:30:14');
+
+    expect(datoTid).toBe('31.08.2024 kl.12:30');
+  });
+
+  test('sjekk - harTallverdi', () => {
+    const ti = harTallverdi(10);
+    const minusTi = harTallverdi(-10);
+    const talletNull = harTallverdi(0);
+    const tiStreng = harTallverdi('10');
+    const minusTiStreng = harTallverdi('-10');
+    const talletNullStreng = harTallverdi('0');
+
+    const udefinert = harTallverdi(undefined);
+    const verdienNull = harTallverdi(null);
+    const streng = harTallverdi('streng');
+    const tomStreng = harTallverdi('');
+
+    expect(ti).toBe(true);
+    expect(minusTi).toBe(true);
+    expect(talletNull).toBe(true);
+    expect(tiStreng).toBe(true);
+    expect(minusTiStreng).toBe(true);
+    expect(talletNullStreng).toBe(true);
+
+    expect(udefinert).toBe(false);
+    expect(verdienNull).toBe(false);
+    expect(streng).toBe(false);
+    expect(tomStreng).toBe(false);
+  });
+
+  // Kan ikke nødvendigvis sjekke likhet med toBe() på grunn av at funksjonen ruker toLocaleString:
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
+  // Får derfor ikke testet formaterTallMedTusenSKille() på en god måte
+});

--- a/src/utils/formatter.test.ts
+++ b/src/utils/formatter.test.ts
@@ -4,7 +4,6 @@ import {
   formaterIsoDatoTid,
   formaterIsoMånedÅr,
   formaterNullableIsoDato,
-  formaterTallMedTusenSkille,
   harTallverdi,
 } from './formatter';
 

--- a/src/utils/formatter.test.ts
+++ b/src/utils/formatter.test.ts
@@ -4,6 +4,7 @@ import {
   formaterIsoDatoTid,
   formaterIsoMånedÅr,
   formaterNullableIsoDato,
+  formaterTallMedTusenSkille,
   harTallverdi,
 } from './formatter';
 
@@ -40,6 +41,18 @@ describe('sjekk - formatering av tall, dato og tid', () => {
     expect(datoTid).toBe('31.08.2024 kl.12:30');
   });
 
+  test('skal formatere tall med tusenskille', () => {
+    expect(formaterTallMedTusenSkille(10)).toBe('10');
+    expect(formaterTallMedTusenSkille(100)).toBe('100');
+    expect(formaterTallMedTusenSkille(1000)).toBe('1\xa0000');
+    expect(formaterTallMedTusenSkille(10000)).toBe('10\xa0000');
+    expect(formaterTallMedTusenSkille(100000)).toBe('100\xa0000');
+    expect(formaterTallMedTusenSkille(1000000)).toBe('1\xa0000\xa0000');
+    expect(formaterTallMedTusenSkille(10000000)).toBe('10\xa0000\xa0000');
+    expect(formaterTallMedTusenSkille(100000000)).toBe('100\xa0000\xa0000');
+    expect(formaterTallMedTusenSkille(1000000000)).toBe('1\xa0000\xa0000\xa0000');
+  });
+
   test('sjekk - harTallverdi', () => {
     const ti = harTallverdi(10);
     const minusTi = harTallverdi(-10);
@@ -65,8 +78,4 @@ describe('sjekk - formatering av tall, dato og tid', () => {
     expect(streng).toBe(false);
     expect(tomStreng).toBe(false);
   });
-
-  // Kan ikke nødvendigvis sjekke likhet med toBe() på grunn av at funksjonen ruker toLocaleString:
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
-  // Får derfor ikke testet formaterTallMedTusenSKille() på en god måte
 });

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -18,7 +18,7 @@ export const formaterIsoDato = (dato: string): string => {
   return parseISO(dato).toLocaleDateString('no-NO', datoFormat);
 };
 
-export const formaterIsoÅrMåned = (dato: string): string => {
+export const formaterIsoMånedÅr = (dato: string): string => {
   return parseISO(dato).toLocaleDateString('no-NO', årMånedFormat);
 };
 
@@ -27,7 +27,7 @@ export const formaterIsoDatoTid = (dato: string): string => {
 };
 
 export const formaterTallMedTusenSkille = (verdi?: number): string =>
-  harTallverdi(verdi) ? Number(verdi).toLocaleString('no-NO', { currency: 'NOK' }) : '';
+  harTallverdi(verdi) ? Number(verdi).toLocaleString('no-NO') : '';
 
 export const harTallverdi = (verdi: number | undefined | null | string): boolean =>
-  verdi !== undefined && verdi !== null;
+  verdi !== undefined && verdi !== null && verdi !== '' && !isNaN(Number(verdi.toString()));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,4 +27,7 @@
   "include": [
     "src"
   ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Innfører frontend-testing for minside:
* Drar inn [vitest](https://vitest.dev/) som dependency
* Legger til eksludering av testfiler `"src/**/*.test.ts"` i `tsconfig.json`
* Legger til at tester skal kjøres i deploy-pipelinen (`npm run test` i .yaml filer)

Dokumentasjon:
https://vitest.dev/

Expect-apiet:
https://vitest.dev/api/expect

Testfiler legges i samme mappe som den filen den prøver å teste ligger i. Kjør opp lokal testing ved `npm run test`. Denne er satt opp til å ekskludere build-mappen.

Dersom man ønsker å kjøre opp tester i interaktiv-modus kan man kjøre:
`vitest run`

![Skjermbilde 2024-03-08 kl  11 56 48](https://github.com/navikt/familie-ef-minside/assets/32769446/0e0361f8-e28c-4fec-84a9-03cc42b9fa19)
