### PR TITLE
Vise inntekt og samordningsfradrag på min side for overgangsstønad

### DIFF
--- a/src/hooks/useSkjermstørrelseHook.ts
+++ b/src/hooks/useSkjermstørrelseHook.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+import { desktop } from '../utils/constants';
+
+export const useSkjermstørrelseHook = () => {
+  const [erLitenSkjerm, setErLitenSkjerm] = useState<boolean>(window.innerWidth < desktop);
+
+  function handleWindowSizeChange() {
+    setErLitenSkjerm(window.innerWidth < desktop);
+  }
+  useEffect(() => {
+    window.addEventListener('resize', handleWindowSizeChange);
+    return () => {
+      window.removeEventListener('resize', handleWindowSizeChange);
+    };
+  }, []);
+
+  return { erLitenSkjerm };
+};

--- a/src/interfaces/stønader.ts
+++ b/src/interfaces/stønader.ts
@@ -17,6 +17,8 @@ export interface Stønadsperiode {
   fraDato: string;
   tilDato: string;
   beløp: number;
+  inntektsgrunnlag: number; // Gjelder OS
+  samordningsfradrag: number; // Gjelder OS
 }
 
 export enum PeriodeStatus {

--- a/src/pages/Stønadoversikt/StønadTabell.tsx
+++ b/src/pages/Stønadoversikt/StønadTabell.tsx
@@ -1,27 +1,14 @@
 import React from 'react';
-import { Stønad, Stønadsperiode, StønadType } from '../../interfaces/stønader';
-import { Alert, BodyLong, HStack, Table } from '@navikt/ds-react';
-import {
-  formaterIsoDato,
-  formaterIsoMånedÅr,
-  formaterTallMedTusenSkille,
-} from '../../utils/formatter';
-import styled from 'styled-components';
-import { contentWidthMobile } from '../../utils/constants';
-import { utledBrødtekst, utledHeaderTekst, utledKolonnebredde, utledPerioder } from './utils';
+import { Stønad, StønadType } from '../../interfaces/stønader';
+import { Alert } from '@navikt/ds-react';
+import StønadTabellEnkel from './StønadTabellEnkel';
+import StønadTabellAvansert from './StønadTabellAvansert';
+import { utledPerioder } from './utils';
 
 interface Props {
   stønad: Stønad;
   stønadType: StønadType;
 }
-
-const Tabell = styled(Table)`
-  max-width: ${contentWidthMobile}px;
-`;
-
-const BeløpWrapper = styled(HStack)<{ bredde: string }>`
-  width: ${(props) => props.bredde};
-`;
 
 const StønadTabell: React.FC<Props> = ({ stønad, stønadType }) => {
   const harStønad = stønad.perioder.length > 0;
@@ -31,67 +18,12 @@ const StønadTabell: React.FC<Props> = ({ stønad, stønadType }) => {
       <Alert variant="info">Vi fant ingen utbetalingsperioder som gjelder {stønadType}.</Alert>
     );
   }
-  const brødTekst = utledBrødtekst(stønadType);
   const tabellPerioder = utledPerioder(stønadType, stønad.perioder);
 
-  const størstBeløp = Math.max(...tabellPerioder.map((periode) => periode.beløp));
-  const kolonneBredde = utledKolonnebredde(størstBeløp);
-
-  return (
-    <>
-      <BodyLong>{brødTekst}</BodyLong>
-      <Tabell>
-        <TabellHeader stønadType={stønadType} />
-        <Table.Body>
-          {tabellPerioder.map((periode) => (
-            <TabellRad
-              key={periode.fraDato + periode.tilDato}
-              periode={periode}
-              stønadType={stønadType}
-              kolonneBredde={kolonneBredde}
-            />
-          ))}
-        </Table.Body>
-      </Tabell>
-    </>
-  );
-};
-
-const TabellHeader: React.FC<{ stønadType: StønadType }> = ({ stønadType }) => {
-  const { headerCelle1, headerCelle2 } = utledHeaderTekst(stønadType);
-
-  return (
-    <Table.Header>
-      <Table.Row>
-        <Table.HeaderCell>{headerCelle1}</Table.HeaderCell>
-        <Table.HeaderCell>{headerCelle2}</Table.HeaderCell>
-      </Table.Row>
-    </Table.Header>
-  );
-};
-
-const TabellRad: React.FC<{
-  periode: Stønadsperiode;
-  stønadType: StønadType;
-  kolonneBredde: string;
-}> = ({ periode, stønadType, kolonneBredde }) => {
-  const fraDato = formaterIsoDato(periode.fraDato);
-  const tilDato = formaterIsoDato(periode.tilDato);
-  const månedÅr = formaterIsoMånedÅr(periode.fraDato);
-
-  const beløpsperiode = stønadType === 'skolepenger' ? `${månedÅr}` : `${fraDato} - ${tilDato}`;
-
-  const beløp = `${formaterTallMedTusenSkille(periode.beløp)} kr`;
-
-  return (
-    <Table.Row>
-      <Table.DataCell>{beløpsperiode}</Table.DataCell>
-      <Table.DataCell align="right">
-        <BeløpWrapper bredde={kolonneBredde} justify="end">
-          {beløp}
-        </BeløpWrapper>
-      </Table.DataCell>
-    </Table.Row>
+  return stønadType === 'overgangsstønad' ? (
+    <StønadTabellAvansert stønadType={stønadType} stønadsperioder={tabellPerioder} />
+  ) : (
+    <StønadTabellEnkel stønadType={stønadType} stønadsperioder={tabellPerioder} />
   );
 };
 

--- a/src/pages/Stønadoversikt/StønadTabellAvansert.tsx
+++ b/src/pages/Stønadoversikt/StønadTabellAvansert.tsx
@@ -1,0 +1,140 @@
+import React, { ReactNode } from 'react';
+import { Stønadsperiode, StønadType } from '../../interfaces/stønader';
+import { BodyLong, HStack, Table } from '@navikt/ds-react';
+import { formaterIsoDato, formaterTallMedTusenSkille } from '../../utils/formatter';
+import styled from 'styled-components';
+import { contentWidthDesktop, contentWidthMobile } from '../../utils/constants';
+import { utledBrødtekst, utledHeaderTekst, utledKolonnebredde } from './utils';
+import { useSkjermstørrelseHook } from '../../hooks/useSkjermstørrelseHook';
+
+interface Props {
+  stønadsperioder: Stønadsperiode[];
+  stønadType: StønadType;
+}
+
+const Tabell = styled(Table)<{ bredde: string }>`
+  max-width: ${(props) => props.bredde};
+`;
+
+const BeløpWrapper = styled(HStack)<{ bredde: string }>`
+  width: ${(props) => props.bredde};
+`;
+
+const maksBeløpForPeriode = (ekspanderbar: boolean) => (periode: Stønadsperiode) =>
+  ekspanderbar
+    ? periode.beløp
+    : Math.max(periode.samordningsfradrag, periode.inntektsgrunnlag, periode.beløp);
+
+const StønadTabellAvansert: React.FC<Props> = ({ stønadsperioder, stønadType }) => {
+  const { erLitenSkjerm } = useSkjermstørrelseHook();
+  const skjermbredde = erLitenSkjerm ? `${contentWidthMobile}px` : `${contentWidthDesktop}px`;
+
+  const størstBeløp = Math.max(...stønadsperioder.map(maksBeløpForPeriode(erLitenSkjerm)));
+  const kolonneBredde = utledKolonnebredde(størstBeløp);
+  const harSamordningsfradrag = stønadsperioder.some((periode) => periode.samordningsfradrag > 0);
+  return (
+    <>
+      <BodyLong>{utledBrødtekst(stønadType)}</BodyLong>
+      <Tabell bredde={skjermbredde}>
+        <TabellHeader
+          stønadType={stønadType}
+          ekspanderbar={erLitenSkjerm}
+          harSamordningsfradrag={harSamordningsfradrag}
+        />
+        <Table.Body>
+          {stønadsperioder.map((periode) => (
+            <TabellRad
+              key={periode.fraDato + periode.tilDato}
+              periode={periode}
+              kolonneBredde={kolonneBredde}
+              ekspanderbar={erLitenSkjerm}
+              harSamordningsfradrag={harSamordningsfradrag}
+            />
+          ))}
+        </Table.Body>
+      </Tabell>
+    </>
+  );
+};
+
+const TabellHeader: React.FC<{
+  stønadType: StønadType;
+  ekspanderbar: boolean;
+  harSamordningsfradrag: boolean;
+}> = ({ stønadType, ekspanderbar, harSamordningsfradrag }) => {
+  const { headerPeriode, headerBeløp, headerInntekt, headerSamordningsfradrag } =
+    utledHeaderTekst(stønadType);
+
+  return (
+    <Table.Header>
+      <Table.Row>
+        {ekspanderbar && <Table.HeaderCell />}
+        <Table.HeaderCell>{headerPeriode}</Table.HeaderCell>
+        {!ekspanderbar && <Table.HeaderCell>{headerInntekt}</Table.HeaderCell>}
+        {!ekspanderbar && harSamordningsfradrag && (
+          <Table.HeaderCell>{headerSamordningsfradrag}</Table.HeaderCell>
+        )}
+        <Table.HeaderCell>{headerBeløp}</Table.HeaderCell>
+      </Table.Row>
+    </Table.Header>
+  );
+};
+
+const VerdiCelle: React.FC<{ bredde: string; children: ReactNode }> = ({ bredde, children }) => {
+  return (
+    <Table.DataCell align="right">
+      <BeløpWrapper bredde={bredde} justify="end">
+        {children}
+      </BeløpWrapper>
+    </Table.DataCell>
+  );
+};
+
+const TabellRad: React.FC<{
+  periode: Stønadsperiode;
+  kolonneBredde: string;
+  ekspanderbar: boolean;
+  harSamordningsfradrag: boolean;
+}> = ({ periode, kolonneBredde, ekspanderbar, harSamordningsfradrag }) => {
+  const fraDato = formaterIsoDato(periode.fraDato);
+  const tilDato = formaterIsoDato(periode.tilDato);
+
+  const beløpsperiode = `${fraDato} - ${tilDato}`;
+
+  const beløp = `${formaterTallMedTusenSkille(periode.beløp)} kr`;
+
+  return ekspanderbar ? (
+    <Table.ExpandableRow content={<UtvidetTabellRad periode={periode} />}>
+      <Table.DataCell>{beløpsperiode}</Table.DataCell>
+      <VerdiCelle bredde={kolonneBredde}>{beløp}</VerdiCelle>
+    </Table.ExpandableRow>
+  ) : (
+    <Table.Row>
+      <Table.DataCell>{beløpsperiode}</Table.DataCell>
+      <VerdiCelle bredde={kolonneBredde}>
+        {formaterTallMedTusenSkille(periode.inntektsgrunnlag)}
+      </VerdiCelle>
+      {harSamordningsfradrag && (
+        <VerdiCelle bredde={kolonneBredde}>
+          {formaterTallMedTusenSkille(periode.samordningsfradrag)}
+        </VerdiCelle>
+      )}
+      <VerdiCelle bredde={kolonneBredde}>{beløp}</VerdiCelle>
+    </Table.Row>
+  );
+};
+
+const UtvidetTabellRad: React.FC<{
+  periode: Stønadsperiode;
+}> = ({ periode }) => {
+  return (
+    <>
+      <div>Inntektsgrunnlag: {formaterTallMedTusenSkille(periode.inntektsgrunnlag)} kr</div>
+      {periode.samordningsfradrag > 0 && (
+        <div>Uføretrygd: {formaterTallMedTusenSkille(periode.samordningsfradrag)} kr</div>
+      )}
+    </>
+  );
+};
+
+export default StønadTabellAvansert;

--- a/src/pages/Stønadoversikt/StønadTabellAvansert.tsx
+++ b/src/pages/Stønadoversikt/StønadTabellAvansert.tsx
@@ -15,6 +15,10 @@ interface Props {
 const samordningsfradragHjelpetekst = `Hvis du får uføretrygd, gjenlevendepensjon eller EØS-familieytelse, vil vi trekke dette månedsbeløpet fra det du får i overgangsstønad. 
   Dette gjør vi før skatt. Vi holder barnetillegget utenfor.`;
 
+const inntektsgrunnlagHjelpetekst = `Vi beregner overgangsstønaden ut ifra inntekten du har eller kan forvente å få i tiden som kommer. Som hovedregel bruker vi inntektsopplysninger arbeidsgiverne dine har meldt inn til offentlige registre. 
+  Vi regner om månedsinntekten din til årsinntekt
+`;
+
 const Tabell = styled(Table)<{ bredde: string }>`
   max-width: ${(props) => props.bredde};
 `;
@@ -73,7 +77,14 @@ const TabellHeader: React.FC<{
       <Table.Row>
         {ekspanderbar && <Table.HeaderCell />}
         <Table.HeaderCell>{headerPeriode}</Table.HeaderCell>
-        {!ekspanderbar && <Table.HeaderCell>{headerInntekt}</Table.HeaderCell>}
+        {!ekspanderbar && (
+          <Table.HeaderCell>
+            <HStack gap={'1'}>
+              {headerInntekt}
+              <HelpText>{inntektsgrunnlagHjelpetekst}</HelpText>
+            </HStack>
+          </Table.HeaderCell>
+        )}
         {!ekspanderbar && harSamordningsfradrag && (
           <Table.HeaderCell>
             <HStack gap={'1'}>
@@ -137,7 +148,10 @@ const UtvidetTabellRad: React.FC<{
 }> = ({ periode }) => {
   return (
     <>
-      <div>Inntektsgrunnlag: {formaterTallMedTusenSkille(periode.inntektsgrunnlag)} kr</div>
+      <HStack gap={'1'}>
+        Inntektsgrunnlag: {formaterTallMedTusenSkille(periode.inntektsgrunnlag)} kr{' '}
+        <HelpText>{inntektsgrunnlagHjelpetekst}</HelpText>
+      </HStack>
       {periode.samordningsfradrag > 0 && (
         <HStack gap={'1'}>
           Samordning: {formaterTallMedTusenSkille(periode.samordningsfradrag)} kr{' '}

--- a/src/pages/Stønadoversikt/StønadTabellAvansert.tsx
+++ b/src/pages/Stønadoversikt/StønadTabellAvansert.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { Stønadsperiode, StønadType } from '../../interfaces/stønader';
-import { BodyLong, HStack, Table } from '@navikt/ds-react';
+import { BodyLong, HelpText, HStack, Table } from '@navikt/ds-react';
 import { formaterIsoDato, formaterTallMedTusenSkille } from '../../utils/formatter';
 import styled from 'styled-components';
 import { contentWidthDesktop, contentWidthMobile } from '../../utils/constants';
@@ -11,6 +11,9 @@ interface Props {
   stønadsperioder: Stønadsperiode[];
   stønadType: StønadType;
 }
+
+const samordningsfradragHjelpetekst = `Hvis du får uføretrygd, gjenlevendepensjon eller EØS-familieytelse, vil vi trekke dette månedsbeløpet fra det du får i overgangsstønad. 
+  Dette gjør vi før skatt. Vi holder barnetillegget utenfor.`;
 
 const Tabell = styled(Table)<{ bredde: string }>`
   max-width: ${(props) => props.bredde};
@@ -72,7 +75,12 @@ const TabellHeader: React.FC<{
         <Table.HeaderCell>{headerPeriode}</Table.HeaderCell>
         {!ekspanderbar && <Table.HeaderCell>{headerInntekt}</Table.HeaderCell>}
         {!ekspanderbar && harSamordningsfradrag && (
-          <Table.HeaderCell>{headerSamordningsfradrag}</Table.HeaderCell>
+          <Table.HeaderCell>
+            <HStack gap={'1'}>
+              {headerSamordningsfradrag}
+              <HelpText>{samordningsfradragHjelpetekst}</HelpText>
+            </HStack>
+          </Table.HeaderCell>
         )}
         <Table.HeaderCell>{headerBeløp}</Table.HeaderCell>
       </Table.Row>
@@ -131,7 +139,10 @@ const UtvidetTabellRad: React.FC<{
     <>
       <div>Inntektsgrunnlag: {formaterTallMedTusenSkille(periode.inntektsgrunnlag)} kr</div>
       {periode.samordningsfradrag > 0 && (
-        <div>Uføretrygd: {formaterTallMedTusenSkille(periode.samordningsfradrag)} kr</div>
+        <HStack gap={'1'}>
+          Samordning: {formaterTallMedTusenSkille(periode.samordningsfradrag)} kr{' '}
+          <HelpText>{samordningsfradragHjelpetekst}</HelpText>
+        </HStack>
       )}
     </>
   );

--- a/src/pages/Stønadoversikt/StønadTabellEnkel.tsx
+++ b/src/pages/Stønadoversikt/StønadTabellEnkel.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Stønadsperiode, StønadType } from '../../interfaces/stønader';
+import { BodyLong, HStack, Table } from '@navikt/ds-react';
+import {
+  formaterIsoDato,
+  formaterIsoMånedÅr,
+  formaterTallMedTusenSkille,
+} from '../../utils/formatter';
+import styled from 'styled-components';
+import { contentWidthMobile } from '../../utils/constants';
+import { utledBrødtekst, utledHeaderTekst, utledKolonnebredde } from './utils';
+
+interface Props {
+  stønadsperioder: Stønadsperiode[];
+  stønadType: StønadType;
+}
+
+const Tabell = styled(Table)`
+  max-width: ${contentWidthMobile}px;
+`;
+
+const BeløpWrapper = styled(HStack)<{ bredde: string }>`
+  width: ${(props) => props.bredde};
+`;
+
+const StønadTabellEnkel: React.FC<Props> = ({ stønadsperioder, stønadType }) => {
+  const størstBeløp = Math.max(...stønadsperioder.map((periode) => periode.beløp));
+  const kolonneBredde = utledKolonnebredde(størstBeløp);
+
+  return (
+    <>
+      <BodyLong>{utledBrødtekst(stønadType)}</BodyLong>
+      <Tabell>
+        <TabellHeader stønadType={stønadType} />
+        <Table.Body>
+          {stønadsperioder.map((periode) => (
+            <TabellRad
+              key={periode.fraDato + periode.tilDato}
+              periode={periode}
+              stønadType={stønadType}
+              kolonneBredde={kolonneBredde}
+            />
+          ))}
+        </Table.Body>
+      </Tabell>
+    </>
+  );
+};
+
+const TabellHeader: React.FC<{ stønadType: StønadType }> = ({ stønadType }) => {
+  const { headerPeriode, headerBeløp } = utledHeaderTekst(stønadType);
+
+  return (
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell>{headerPeriode}</Table.HeaderCell>
+        <Table.HeaderCell>{headerBeløp}</Table.HeaderCell>
+      </Table.Row>
+    </Table.Header>
+  );
+};
+
+const TabellRad: React.FC<{
+  periode: Stønadsperiode;
+  stønadType: StønadType;
+  kolonneBredde: string;
+}> = ({ periode, stønadType, kolonneBredde }) => {
+  const fraDato = formaterIsoDato(periode.fraDato);
+  const tilDato = formaterIsoDato(periode.tilDato);
+  const månedÅr = formaterIsoMånedÅr(periode.fraDato);
+
+  const beløpsperiode = stønadType === 'skolepenger' ? `${månedÅr}` : `${fraDato} - ${tilDato}`;
+
+  const beløp = `${formaterTallMedTusenSkille(periode.beløp)} kr`;
+
+  return (
+    <Table.Row>
+      <Table.DataCell>{beløpsperiode}</Table.DataCell>
+      <Table.DataCell align="right">
+        <BeløpWrapper bredde={kolonneBredde} justify="end">
+          {beløp}
+        </BeløpWrapper>
+      </Table.DataCell>
+    </Table.Row>
+  );
+};
+
+export default StønadTabellEnkel;

--- a/src/pages/Stønadoversikt/utils.test.ts
+++ b/src/pages/Stønadoversikt/utils.test.ts
@@ -10,6 +10,7 @@ import {
   utledVedtak,
 } from './utils';
 import { JournalpostType, Variantformat } from '../../interfaces/journalpost';
+import { Stønadsperiode } from '../../interfaces/stønader';
 
 describe('sjekk - formateringer av tekst og perioder stønadsidene', () => {
   test('skal utlede breadcrumb gitt stønadType', () => {
@@ -70,11 +71,13 @@ describe('sjekk - formateringer av tekst og perioder stønadsidene', () => {
     const skolepenger = utledHeaderTekst('skolepenger');
 
     expect(overgangsstønad).toEqual({
-      headerCelle1: 'Periode',
-      headerCelle2: 'Beløp per måned før skatt',
+      headerPeriode: 'Periode',
+      headerBeløp: 'Beløp per måned før skatt',
+      headerSamordningsfradrag: 'Uføretrygd',
+      headerInntekt: 'Inntektsgrunnlag',
     });
-    expect(barnetilsyn).toEqual({ headerCelle1: 'Periode', headerCelle2: 'Beløp per måned' });
-    expect(skolepenger).toEqual({ headerCelle1: 'Utbetalingsmåned', headerCelle2: 'Beløp' });
+    expect(barnetilsyn).toEqual({ headerPeriode: 'Periode', headerBeløp: 'Beløp per måned' });
+    expect(skolepenger).toEqual({ headerPeriode: 'Utbetalingsmåned', headerBeløp: 'Beløp' });
   });
 
   test('skal utlede kolonnebredde gitt beløp', () => {
@@ -206,6 +209,20 @@ describe('sjekk - skal sortere stønadsperiodene på dato og slå sammen sammenh
     expect(perioder[2]).toEqual(lagPeriode('2023-05-01', '2023-10-31', 22000));
     expect(perioder[3]).toEqual(lagPeriode('2023-01-01', '2023-03-30', 20900));
   });
+
+  test('skal sortere og slå sammen perioder gitt sammenhengende perioder med like verdier for beløp, inntektsgrunnlag og samordningsfradrag', () => {
+    const perioder = utledPerioder(
+      'overgangsstønad',
+      sammenHengendePerioderMedLiktBeløpMenUlikSamordningOgInntekt()
+    );
+
+    expect(perioder).toHaveLength(5);
+    expect(perioder[0]).toEqual(lagPeriode('2023-10-01', '2024-04-30', 22000));
+    expect(perioder[1]).toEqual(lagPeriode('2023-08-01', '2023-09-30', 22000, 200000, 10000));
+    expect(perioder[2]).toEqual(lagPeriode('2023-06-01', '2023-07-31', 22000, 300000));
+    expect(perioder[3]).toEqual(lagPeriode('2023-05-01', '2023-05-31', 22000));
+    expect(perioder[4]).toEqual(lagPeriode('2023-01-01', '2023-04-30', 20900));
+  });
 });
 
 describe('sjekk - skal sortere stønadsperiodene på dato og slå sammen sammenhengende perioder med like beløp for barnetilsyn ', () => {
@@ -253,6 +270,17 @@ const sammenHengendePerioderMedLiktBeløp = () => [
   lagPeriode('2023-05-01', '2023-12-31', 22000),
   lagPeriode('2024-01-01', '2024-04-30', 22000),
   lagPeriode('2024-05-01', '2024-08-31', 2000),
+];
+
+const sammenHengendePerioderMedLiktBeløpMenUlikSamordningOgInntekt = () => [
+  lagPeriode('2023-01-01', '2023-04-30', 20900, 0, 0),
+  lagPeriode('2023-05-01', '2023-05-31', 22000, 0, 0),
+  lagPeriode('2023-06-01', '2023-06-30', 22000, 300000, 0),
+  lagPeriode('2023-07-01', '2023-07-31', 22000, 300000, 0),
+  lagPeriode('2023-08-01', '2023-08-31', 22000, 200000, 10000),
+  lagPeriode('2023-09-01', '2023-09-30', 22000, 200000, 10000),
+  lagPeriode('2023-10-01', '2023-12-31', 22000, 0, 0),
+  lagPeriode('2024-01-01', '2024-04-30', 22000, 0, 0),
 ];
 
 const sammenHengendePerioderMedLiktBeløpIkkeSortert = () => [
@@ -309,11 +337,19 @@ const dummyJournalposter = [
   lagJournalpost('Vedtak om innvilget overgangsstønad'),
 ];
 
-const lagPeriode = (fra: string, til: string, beløp: number) => {
+const lagPeriode = (
+  fra: string,
+  til: string,
+  beløp: number,
+  inntektsgrunnlag: number = 0,
+  samordningsfradrag: number = 0
+): Stønadsperiode => {
   return {
     fraDato: fra,
     tilDato: til,
     beløp: beløp,
+    inntektsgrunnlag: inntektsgrunnlag,
+    samordningsfradrag: samordningsfradrag,
   };
 };
 

--- a/src/pages/Stønadoversikt/utils.test.ts
+++ b/src/pages/Stønadoversikt/utils.test.ts
@@ -55,7 +55,10 @@ describe('sjekk - formateringer av tekst og perioder stønadsidene', () => {
     const skolepenger = utledBrødtekst('skolepenger');
 
     expect(overgangsstønad).toBe(
-      'Tabellen viser periodene dine med overgangsstønad og hvor mye du har fått eller får i stønad\n        per måned før skatt. For å se hvordan vi har regnet ut stønadsbeløpet, må du lese vedtaket\n        ditt. Du finner alle vedtakene dine i dokumentoversikten lengre ned på siden.'
+      `Tabellen viser periodene dine med overgangsstønad, hvor mye du har fått eller får i stønad 
+      per måned og hvilken inntekt vi har brukt for å beregne stønaden din. 
+      For å se hvordan vi har beregnet stønaden din, må du lese vedtaket ditt. 
+      Du finner vedtakene dine i dokumentoversikten lengre ned på siden.`
     );
     expect(barnetilsyn).toBe(
       'Tabellen viser periodene dine med barnetilsyn og hvor mye du har fått eller får i stønad\n        per måned. For å se hvordan vi har regnet ut stønadsbeløpet, må du lese vedtaket\n        ditt. Du finner alle vedtakene dine i dokumentoversikten lengre ned på siden.'

--- a/src/pages/Stønadoversikt/utils.test.ts
+++ b/src/pages/Stønadoversikt/utils.test.ts
@@ -73,7 +73,7 @@ describe('sjekk - formateringer av tekst og perioder stønadsidene', () => {
     expect(overgangsstønad).toEqual({
       headerPeriode: 'Periode',
       headerBeløp: 'Beløp per måned før skatt',
-      headerSamordningsfradrag: 'Uføretrygd',
+      headerSamordningsfradrag: 'Samordning',
       headerInntekt: 'Inntektsgrunnlag',
     });
     expect(barnetilsyn).toEqual({ headerPeriode: 'Periode', headerBeløp: 'Beløp per måned' });

--- a/src/pages/Stønadoversikt/utils.ts
+++ b/src/pages/Stønadoversikt/utils.ts
@@ -69,6 +69,8 @@ const mergeSammenhengendePerioderMedLikeBeløp = (perioder: Stønadsperiode[]) =
         fraDato: prevPeriode.fraDato,
         tilDato: periode.tilDato,
         beløp: periode.beløp,
+        inntektsgrunnlag: periode.inntektsgrunnlag,
+        samordningsfradrag: periode.samordningsfradrag,
       } as Stønadsperiode;
 
       return [...acc.slice(0, -1), sammenslåttPeriode];
@@ -109,16 +111,23 @@ export const utledBrødtekst = (stønadType: StønadType) => {
 export const utledHeaderTekst = (stønadType: StønadType) => {
   switch (stønadType) {
     case 'overgangsstønad':
-      return { headerCelle1: 'Periode', headerCelle2: 'Beløp per måned før skatt' };
+      return {
+        headerPeriode: 'Periode',
+        headerBeløp: 'Beløp per måned før skatt',
+        headerInntekt: 'Inntektsgrunnlag',
+        headerSamordningsfradrag: 'Uføretrygd',
+      };
     case 'barnetilsyn':
-      return { headerCelle1: 'Periode', headerCelle2: 'Beløp per måned' };
+      return { headerPeriode: 'Periode', headerBeløp: 'Beløp per måned' };
     case 'skolepenger':
-      return { headerCelle1: 'Utbetalingsmåned', headerCelle2: 'Beløp' };
+      return { headerPeriode: 'Utbetalingsmåned', headerBeløp: 'Beløp' };
   }
 };
 
 const harSammeBeløp = (periodeLeft: Stønadsperiode, periodeRight: Stønadsperiode) =>
-  periodeLeft.beløp === periodeRight.beløp;
+  periodeLeft.beløp === periodeRight.beløp &&
+  periodeLeft.inntektsgrunnlag === periodeRight.inntektsgrunnlag &&
+  periodeLeft.samordningsfradrag === periodeRight.samordningsfradrag;
 
 // Denne utleder bredde til beløpskolonne i tabell. For høyrejustering av beløp.
 export const utledKolonnebredde = (beløp: number) => {

--- a/src/pages/Stønadoversikt/utils.ts
+++ b/src/pages/Stønadoversikt/utils.ts
@@ -98,8 +98,7 @@ export const utledBrødtekst = (stønadType: StønadType) => {
       return `Tabellen viser periodene dine med overgangsstønad, hvor mye du har fått eller får i stønad 
       per måned og hvilken inntekt vi har brukt for å beregne stønaden din. 
       For å se hvordan vi har beregnet stønaden din, må du lese vedtaket ditt. 
-      Du finner vedtakene dine i dokumentoversikten lengre ned på siden.
-`;
+      Du finner vedtakene dine i dokumentoversikten lengre ned på siden.`;
     case 'barnetilsyn':
       return `Tabellen viser periodene dine med barnetilsyn og hvor mye du har fått eller får i stønad
         per måned. For å se hvordan vi har regnet ut stønadsbeløpet, må du lese vedtaket

--- a/src/pages/Stønadoversikt/utils.ts
+++ b/src/pages/Stønadoversikt/utils.ts
@@ -95,9 +95,11 @@ export const utledVedtak = (journalposter: Journalpost[], stønadType: StønadTy
 export const utledBrødtekst = (stønadType: StønadType) => {
   switch (stønadType) {
     case 'overgangsstønad':
-      return `Tabellen viser periodene dine med overgangsstønad og hvor mye du har fått eller får i stønad
-        per måned før skatt. For å se hvordan vi har regnet ut stønadsbeløpet, må du lese vedtaket
-        ditt. Du finner alle vedtakene dine i dokumentoversikten lengre ned på siden.`;
+      return `Tabellen viser periodene dine med overgangsstønad, hvor mye du har fått eller får i stønad 
+      per måned og hvilken inntekt vi har brukt for å beregne stønaden din. 
+      For å se hvordan vi har beregnet stønaden din, må du lese vedtaket ditt. 
+      Du finner vedtakene dine i dokumentoversikten lengre ned på siden.
+`;
     case 'barnetilsyn':
       return `Tabellen viser periodene dine med barnetilsyn og hvor mye du har fått eller får i stønad
         per måned. For å se hvordan vi har regnet ut stønadsbeløpet, må du lese vedtaket
@@ -115,7 +117,7 @@ export const utledHeaderTekst = (stønadType: StønadType) => {
         headerPeriode: 'Periode',
         headerBeløp: 'Beløp per måned før skatt',
         headerInntekt: 'Inntektsgrunnlag',
-        headerSamordningsfradrag: 'Uføretrygd',
+        headerSamordningsfradrag: 'Samordning',
       };
     case 'barnetilsyn':
       return { headerPeriode: 'Periode', headerBeløp: 'Beløp per måned' };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Trenger å vise dette som underlag for hvordan stønaden er beregnet.

Hva gjenstår:

- [x] Begrepsbruk for samordningsfradrag - Uføretrygd/Gjenlevendepensjon/Annen tilsvarende ytelse ? 
- [x] Noe informasjon vedrørende hva inntektsgrunnlag (og samordningsfradrag) faktisk betyr i denne sammenhengen. 

## Kun inntekt - uten samordningsfradrag
![Screenshot 2024-05-10 at 15 34 55](https://github.com/navikt/familie-ef-minside/assets/402915/3cc55822-4c51-460d-af48-c76234dea347)

<img width="485" alt="Screenshot 2024-05-16 at 13 42 17" src="https://github.com/navikt/familie-ef-minside/assets/402915/cb79afd8-c3cc-413e-aa5c-0583132b5540">
<img width="479" alt="Screenshot 2024-05-16 at 13 42 11" src="https://github.com/navikt/familie-ef-minside/assets/402915/8052abb7-d4ca-4868-be38-53ef002e6a41">
<img width="1036" alt="Screenshot 2024-05-16 at 13 41 57" src="https://github.com/navikt/familie-ef-minside/assets/402915/7ae3f0c0-b248-44e6-a614-be9d07ff704f">
<img width="1023" alt="Screenshot 2024-05-16 at 13 41 52" src="https://github.com/navikt/familie-ef-minside/assets/402915/2e136536-6602-4c8d-a115-30ed9317cd4e">
