### PR TITLE
Node 24 + chainguard image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v6.3.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
       - name: Install dependencies

--- a/.github/workflows/build_n_deploy_dev.yaml
+++ b/.github/workflows/build_n_deploy_dev.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v6.3.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
       - name: Npm install, test and build

--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v6.3.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
       - name: Npm install, test and build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24-slim
 
 WORKDIR /app
 COPY build ./build


### PR DESCRIPTION
- Tar i bruk image fra chainguard for å bedre sikkerhet. Det finnes kjente sårbarheter på image som er i bruk.
- Oppdaterer node til 24 da versjon er et stykke bak og dette forbedrere sikkerhet.
